### PR TITLE
5주차 | 바텀시트·캐러셀·친구·홈 퍼블리싱 수정, 펀딩 개설·펀딩 참여 Context API 조건부 렌더링 페이지 이동 및 데이터 관리, 엑세스 토큰 재발급 API 요청 Hook, 그외 코드 리팩토링

### DIFF
--- a/src/api/oauth.js
+++ b/src/api/oauth.js
@@ -19,3 +19,11 @@ export const getAccessTokenKakao = async (code) => {
 };
 
 // 액세스 토큰 재발급
+export const postAccessTokenReissue = async () => {
+  try {
+    const response = await apiAuth.post(`/api/oauth/reissue`);
+    return response;
+  } catch (error) {
+    throw error;
+  }
+};

--- a/src/components/Home/Calendar.jsx
+++ b/src/components/Home/Calendar.jsx
@@ -109,7 +109,7 @@ const Calendar = () => {
       </SDateContainer>
       {bottomSheetShow && (
         <BottomSheetComponent setBottomSheetShow={setBottomSheetShow}>
-          <SSheetLayout>
+          <SBottomSheetContainer>
             <SSpan>
               {selectedDate.month}월 {selectedDate.date}일 {selectedDate.day}
               요일
@@ -132,7 +132,7 @@ const Calendar = () => {
                 </SItemContainer>
               ))}
             </CarouselComponent>
-          </SSheetLayout>
+          </SBottomSheetContainer>
         </BottomSheetComponent>
       )}
     </SLayout>
@@ -213,7 +213,7 @@ const Tag = styled(TagIcon)`
   bottom: 27px;
   z-index: 999;
 `;
-const SSheetLayout = styled.div`
+const SBottomSheetContainer = styled.div`
   display: flex;
   flex-direction: column;
   justify-content: center;

--- a/src/components/Home/Calendar.jsx
+++ b/src/components/Home/Calendar.jsx
@@ -220,7 +220,7 @@ const SBottomSheetContainer = styled.div`
   align-items: center;
   gap: 32px;
 
-  padding: 32px 21px 18px 19px;
+  padding: 48px 20px 18px;
 `;
 const SSpan = styled.span`
   font-size: 20px;

--- a/src/components/common/BottomBackgroundComponent.jsx
+++ b/src/components/common/BottomBackgroundComponent.jsx
@@ -25,6 +25,7 @@ const SLayout = styled.div`
   display: flex;
   justify-content: center;
   position: fixed;
+  left: 50%;
   bottom: 0;
 
   width: 375px;
@@ -33,6 +34,8 @@ const SLayout = styled.div`
 
   border-top: 1px solid var(--gray-100);
   background: var(--white);
+
+  transform: translateX(-50%);
 `;
 
 export default BottomBackgroundComponent;

--- a/src/components/common/BottomModalComponent.jsx
+++ b/src/components/common/BottomModalComponent.jsx
@@ -81,8 +81,8 @@ const SBackgroundDiv = styled.div`
   left: 0;
   z-index: 9999;
 
-  width: 100vw;
-  height: 100vh;
+  width: 100svw;
+  height: 100svh;
 
   background-color: ${({ $open }) =>
     $open ? 'rgba(0, 0, 0, 0.4)' : 'rgba(0, 0, 0, 0)'};

--- a/src/components/common/BottomModalComponent.jsx
+++ b/src/components/common/BottomModalComponent.jsx
@@ -5,8 +5,9 @@
 // (1-2) 부모 컴포넌트에 추가: {bottomModalShow && (<BottomModalComponent></BottomModalComponent>)}
 //
 // 2. 바텀모달 props
-// (2-1) setBottomModalShow - 1-1의 setBottomModalShow
-// (2-2) parentOpen - (4-3) 또는 true
+// (2-1) backgroundAction - SBackgroundDiv 이벤트리스너 활성화 여부
+// (2-2) setBottomModalShow - 1-1의 setBottomModalShow
+// (2-3) parentOpen - (4-3) 또는 true
 // 예시: <BottomModalComponent setBottomModalShow={setBottomModalShow} parentOpen={true}>
 //
 // 3. 바텀모달 내용
@@ -29,7 +30,12 @@ import styled from 'styled-components';
 import { useEffect, useState } from 'react';
 import { createPortal } from 'react-dom';
 
-const BottomModalComponent = ({ setBottomModalShow, parentOpen, children }) => {
+const BottomModalComponent = ({
+  backgroundAction,
+  setBottomModalShow,
+  parentOpen,
+  children,
+}) => {
   const [bottomModalOpen, setBottomModalOpen] = useState(false);
 
   const handleBottomModalClose = () => {
@@ -56,7 +62,9 @@ const BottomModalComponent = ({ setBottomModalShow, parentOpen, children }) => {
 
   const BottomModalUI = (
     <SBackgroundDiv
-      onClick={handleBottomModalClose}
+      onClick={() => {
+        if (backgroundAction) return handleBottomModalClose;
+      }}
       $open={bottomModalOpen && parentOpen}
     >
       <SContainer

--- a/src/components/common/BottomModalComponent.jsx
+++ b/src/components/common/BottomModalComponent.jsx
@@ -39,8 +39,10 @@ const BottomModalComponent = ({
   const [bottomModalOpen, setBottomModalOpen] = useState(false);
 
   const handleBottomModalClose = () => {
-    setBottomModalOpen(false); // 바텀모달 닫기 애니메이션 효과
-    setTimeout(() => setBottomModalShow(false), 300); // 애니메이션 후 언마운트
+    if (backgroundAction) {
+      setBottomModalOpen(false); // 바텀모달 닫기 애니메이션 효과
+      setTimeout(() => setBottomModalShow(false), 300); // 애니메이션 후 언마운트
+    }
   };
 
   useEffect(() => {
@@ -62,9 +64,7 @@ const BottomModalComponent = ({
 
   const BottomModalUI = (
     <SBackgroundDiv
-      onClick={() => {
-        if (backgroundAction) return handleBottomModalClose;
-      }}
+      onClick={handleBottomModalClose}
       $open={bottomModalOpen && parentOpen}
     >
       <SContainer

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -19,6 +19,7 @@
 
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import BottomModalComponent from './BottomModalComponent';
 import icn_cross from '../../assets/common/Bottomsheet/cross.svg';
 
@@ -28,11 +29,15 @@ const BottomSheetComponent = ({
   setBottomSheetShow,
   children,
 }) => {
+  const navigate = useNavigate();
   const [bottomSheetOpen, setBottomSheetOpen] = useState(false);
 
   const handleBottomSheetClose = () => {
     setBottomSheetOpen(false); // 바텀시트 닫기 애니메이션 효과
     setTimeout(() => setBottomSheetShow(false), 300); // 애니메이션 후 언마운트
+  };
+  const handlePageBack = () => {
+    navigate(-1); // 페이지 뒤로가기
   };
 
   useEffect(() => {
@@ -52,7 +57,11 @@ const BottomSheetComponent = ({
         }}
       >
         {closeButton === 'cross' ? (
-          <SCrossButton onClick={handleBottomSheetClose} />
+          <SCrossButton
+            onClick={
+              action === 'back' ? handlePageBack : handleBottomSheetClose
+            }
+          />
         ) : (
           <SBarButton onClick={handleBottomSheetClose} />
         )}

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -86,8 +86,8 @@ const SBarButton = styled.button`
   height: 6px;
   margin: 0 auto;
 
-  background-color: var(--gray-300);
   border-radius: 12px;
+  background-color: var(--gray-300);
 `;
 
 export default BottomSheetComponent;

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -33,11 +33,23 @@ const BottomSheetComponent = ({
   const [bottomSheetOpen, setBottomSheetOpen] = useState(false);
 
   const handleBottomSheetClose = () => {
-    setBottomSheetOpen(false); // 바텀시트 닫기 애니메이션 효과
-    setTimeout(() => setBottomSheetShow(false), 300); // 애니메이션 후 언마운트
+    switch (action) {
+      case 'transition':
+        setBottomSheetOpen(false); // 바텀시트 닫기 애니메이션 효과
+        setTimeout(() => setBottomSheetShow(false), 300); // 애니메이션 후 언마운트
+        break;
+      case 'back':
+        navigate(-1); // 페이지 뒤로가기
+        break;
+    }
   };
-  const handlePageBack = () => {
-    navigate(-1); // 페이지 뒤로가기
+  const renderCloseButton = () => {
+    switch (closeButton) {
+      case 'bar':
+        return <SBarButton onClick={handleBottomSheetClose} />;
+      case 'cross':
+        return <SCrossButton onClick={handleBottomSheetClose} />;
+    }
   };
 
   useEffect(() => {
@@ -46,7 +58,7 @@ const BottomSheetComponent = ({
 
   return (
     <BottomModalComponent
-      backgroundAction={!(action === 'back')}
+      backgroundAction={action === 'transition'}
       setBottomModalShow={setBottomSheetShow}
       parentOpen={bottomSheetOpen}
     >
@@ -55,15 +67,7 @@ const BottomSheetComponent = ({
           event.stopPropagation();
         }}
       >
-        {closeButton === 'cross' ? (
-          <SCrossButton
-            onClick={
-              action === 'back' ? handlePageBack : handleBottomSheetClose
-            }
-          />
-        ) : (
-          <SBarButton onClick={handleBottomSheetClose} />
-        )}
+        {renderCloseButton()}
         <article>{children}</article>
       </SSection>
     </BottomModalComponent>

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -47,7 +47,6 @@ const BottomSheetComponent = ({
         onClick={(event) => {
           event.stopPropagation();
         }}
-        $cross={closeButton === 'cross'}
       >
         {closeButton === 'cross' ? (
           <SCrossButton onClick={handleBottomSheetClose} />
@@ -63,8 +62,6 @@ const BottomSheetComponent = ({
 const SSection = styled.section`
   width: 375px;
   height: 320px;
-  padding-top: ${({ $cross }) => ($cross ? '26px' : '16px')};
-  gap: ${({ $cross }) => ($cross ? '0' : '32')}px;
 
   border-radius: 20px 20px 0px 0px;
   background-color: var(--white);

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -24,8 +24,8 @@ import BottomModalComponent from './BottomModalComponent';
 import icn_cross from '../../assets/common/Bottomsheet/cross.svg';
 
 const BottomSheetComponent = ({
-  closeButton,
-  action,
+  closeButton = 'bar',
+  action = 'transition',
   setBottomSheetShow,
   children,
 }) => {

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -80,12 +80,17 @@ const SCrossButton = styled.button`
   background-repeat: no-repeat;
 `;
 const SBarButton = styled.button`
+  position: absolute;
+  top: 16px;
+  left: 50%;
+
   width: 46px;
   height: 6px;
-  margin: 0 auto;
 
   border-radius: 12px;
   background-color: var(--gray-300);
+
+  transform: translateX(-50%);
 `;
 
 export default BottomSheetComponent;

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -41,8 +41,7 @@ const BottomSheetComponent = ({
   };
 
   useEffect(() => {
-    // 바텀시트 열기 애니메이션 효과
-    setBottomSheetOpen(true);
+    setBottomSheetOpen(true); // 바텀시트 열기 애니메이션 효과
   }, []);
 
   return (

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -19,7 +19,7 @@
 import styled from 'styled-components';
 import { useState, useEffect } from 'react';
 import BottomModalComponent from './BottomModalComponent';
-import { ReactComponent as CrossIcon } from '../../assets/common/Bottomsheet/cross.svg';
+import icn_cross from '../../assets/common/Bottomsheet/cross.svg';
 
 const BottomSheetComponent = ({
   closeButton,
@@ -50,9 +50,7 @@ const BottomSheetComponent = ({
         $cross={closeButton === 'cross'}
       >
         {closeButton === 'cross' ? (
-          <SCrossButton onClick={handleBottomSheetClose}>
-            <CrossIcon />
-          </SCrossButton>
+          <SCrossButton onClick={handleBottomSheetClose} />
         ) : (
           <SBarButton onClick={handleBottomSheetClose} />
         )}
@@ -76,6 +74,12 @@ const SSection = styled.section`
 const SCrossButton = styled.button`
   position: absolute;
   right: 24px;
+
+  width: 20px;
+  height: 20px;
+
+  background-image: url(${icn_cross});
+  background-repeat: no-repeat;
 `;
 const SBarButton = styled.button`
   width: 46px;

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -6,7 +6,8 @@
 //
 // 2. 바텀시트 props
 // (2-1) closeButton - 'bar' 또는 'cross' (기본 'bar')
-// (2-2) setBottomSheetShow - 1-1의 setBottomSheetShow
+// (2-2) action - 'transition' 또는 'back' (기본 'transition')
+// (2-3) setBottomSheetShow - 1-1의 setBottomSheetShow
 // 예시: <BottomSheetComponent closeButton='cross' setBottomSheetShow={setBottomSheetShow}>
 //
 // 3. 바텀시트 내용
@@ -23,6 +24,7 @@ import icn_cross from '../../assets/common/Bottomsheet/cross.svg';
 
 const BottomSheetComponent = ({
   closeButton,
+  action,
   setBottomSheetShow,
   children,
 }) => {
@@ -40,6 +42,7 @@ const BottomSheetComponent = ({
 
   return (
     <BottomModalComponent
+      backgroundAction={!(action === 'back')}
       setBottomModalShow={setBottomSheetShow}
       parentOpen={bottomSheetOpen}
     >

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -70,7 +70,8 @@ const SSection = styled.section`
 `;
 const SCrossButton = styled.button`
   position: absolute;
-  right: 24px;
+  top: 26px;
+  right: 22px;
 
   width: 20px;
   height: 20px;

--- a/src/components/common/BottomSheetComponent.jsx
+++ b/src/components/common/BottomSheetComponent.jsx
@@ -60,8 +60,8 @@ const BottomSheetComponent = ({
 };
 
 const SSection = styled.section`
-  width: 375px;
-  height: 320px;
+  width: fit-content;
+  height: fit-content;
 
   border-radius: 20px 20px 0px 0px;
   background-color: var(--white);

--- a/src/components/common/CarouselComponent.jsx
+++ b/src/components/common/CarouselComponent.jsx
@@ -56,18 +56,10 @@ const CarouselComponent = ({ pageLength, pageWidth, children }) => {
     <SLayout $pageWidth={pageWidth}>
       <SContentContainer
         id='carousel'
-        onPointerDown={(event) => {
-          setFirstX(event.clientX);
-        }}
-        onPointerUp={(event) => {
-          setLastX(event.clientX);
-        }}
-        onTouchStart={(event) => {
-          setFirstX(event.changedTouches[0].clientX);
-        }}
-        onTouchEnd={(event) => {
-          setLastX(event.changedTouches[0].clientX);
-        }}
+        onPointerDown={(event) => setFirstX(event.clientX)}
+        onPointerUp={(event) => setLastX(event.clientX)}
+        onTouchStart={(event) => setFirstX(event.changedTouches[0].clientX)}
+        onTouchEnd={(event) => setLastX(event.changedTouches[0].clientX)}
       >
         {children}
       </SContentContainer>

--- a/src/components/common/CarouselComponent.jsx
+++ b/src/components/common/CarouselComponent.jsx
@@ -71,7 +71,7 @@ const CarouselComponent = ({ pageLength, pageWidth, children }) => {
       >
         {children}
       </SContentContainer>
-      <SPaginationFieldset>
+      <SPaginationFieldset $pageLength={pageLength}>
         {Array.from({ length: pageLength }, (v, i) => i).map((pageNumber) => {
           return (
             <SRadioInput
@@ -112,6 +112,8 @@ const SContentContainer = styled.div`
   flex-flow: row nowrap;
 `;
 const SPaginationFieldset = styled.fieldset`
+  visibility: ${({ $pageLength }) =>
+    $pageLength === 1 ? 'hidden' : 'visible'};
   display: flex;
   flex-flow: row nowrap;
   justify-content: center;

--- a/src/components/common/CarouselComponent.jsx
+++ b/src/components/common/CarouselComponent.jsx
@@ -68,7 +68,6 @@ const CarouselComponent = ({ pageLength, pageWidth, children }) => {
         onTouchEnd={(event) => {
           setLastX(event.changedTouches[0].clientX);
         }}
-        $currentPage={currentPage}
       >
         {children}
       </SContentContainer>

--- a/src/components/common/FundingComponent.jsx
+++ b/src/components/common/FundingComponent.jsx
@@ -1,119 +1,98 @@
 /*
-<SFundingContainer>
+<SFundingListContainer>
   {fundingList.map((funding, index) => (
-      <FundingComponent
-        result={funding}
-        key={index}
-        onClick={() => handleClick(funding)}
-       />
+    <FundingComponent data={funding} key={index} />
   ))}
-</SFundingContainer>
-겉을 SFundingListContainer로 감싸고 map을 이용하면 됩니다. 
-
-fundingList를 api로 받아와 fundingList로 넣어주면 됩니다. 
-const handleClick = (funding) => {
-    funding.status === 'IN_PROGRESS'
-      ? navigate(`/funding-detail/${funding.fundingId}/isOngoing`)
-      : navigate(`/funding-detail/${funding.fundingId}/end`);
-  };
-handleClick 부분은 이렇게 클릭하면 해당 펀딩의 세부 페이지로 가도록 연결해줍니다. 
-
+</SFundingListContainer>
+SFundingListContainer로 감싸고 map을 이용하면 됩니다. 
 */
 
 import styled from 'styled-components';
-import TagComponent from './TagComponent';
 import { useNavigate } from 'react-router-dom';
+import TagComponent from './TagComponent';
 
-const FundingComponent = ({ result, ...props }) => {
+const FundingComponent = ({ data, ...props }) => {
+  const navigate = useNavigate();
+
   return (
-    <SFundingContainer {...props}>
-      <SImageContainer>
-        <img src={result.fundingImageUrl} alt='funding' />
-        <STagWrapper>
-          {result.status === 'IN_PROGRESS' ? (
-            <TagComponent text='진행 중' color='jade' />
-          ) : (
-            <TagComponent text='종료' color='gray' />
-          )}
-        </STagWrapper>
-      </SImageContainer>
-      <STitleWrapper>{result.fundingTitle}</STitleWrapper>
+    <SLayout onClick={() => navigate(`/funding/${data.fundingId}`)} {...props}>
+      <SImg src={data.fundingImageUrl} alt='funding' />
+      <STagWrapper>
+        {data.status === 'IN_PROGRESS' ? (
+          <TagComponent text='진행 중' color='jade' />
+        ) : (
+          <TagComponent text='종료' color='gray' />
+        )}
+      </STagWrapper>
+      <STitleSpan>{data.fundingTitle}</STitleSpan>
       <STextContainer>
-        <STextWrapper id='label'>
-          <p id='label'>개설</p>
-          <p>{result.launcherNickname}</p>
-        </STextWrapper>
-        <STextWrapper>
-          <p id='label'>마감</p>
-          <p>{result.fundingEndDate}</p>
-        </STextWrapper>
+        <SGrayB3>개설</SGrayB3>
+        <SBlackB3>{data.launcherNickname}</SBlackB3>
+        <SGrayB3>마감</SGrayB3>
+        <SBlackB3>{data.fundingEndDate}</SBlackB3>
       </STextContainer>
-    </SFundingContainer>
+    </SLayout>
   );
 };
 
-const SFundingContainer = styled.div`
+const SLayout = styled.div`
   display: flex;
   flex-direction: column;
   align-items: center;
+  position: relative;
 
-  width: 164px;
-  height: 266px;
+  padding: 8px;
+  gap: 12px;
 
   cursor: pointer;
 `;
-const SImageContainer = styled.div`
-  position: relative;
-
+const SImg = styled.img`
   width: 148px;
   height: 148px;
-  margin-top: 8px;
 
   border-radius: 16px;
 `;
 const STagWrapper = styled.div`
   position: absolute;
-  top: 12px;
-  right: 12px;
+  top: 20px;
+  right: 20px;
 `;
-const STitleWrapper = styled.p`
+const STitleSpan = styled.span`
+  display: -webkit-box;
+  overflow: hidden;
+
   width: 140px;
   height: 40px;
-  margin-top: 12px;
 
   font-size: 17px;
-  font-style: normal;
   font-weight: 700;
   line-height: 120%;
-
   text-overflow: ellipsis;
-  overflow: hidden;
-  display: -webkit-box;
+
   -webkit-line-clamp: 2;
   -webkit-box-orient: vertical;
 `;
 const STextContainer = styled.div`
-  display: flex;
-  flex-direction: column;
-  gap: 4px;
-  width: 140px;
+  display: grid;
+  grid-template-columns: repeat(2, auto);
+  gap: 4px 8px;
 `;
-const STextWrapper = styled.div`
-  display: flex;
-  flex-direction: row;
-  gap: 8px;
-
+const SB3 = styled.span`
   font-size: 14px;
-  font-style: normal;
   font-weight: 500;
   line-height: 120%;
+`;
+const SBlackB3 = styled(SB3)`
+  overflow: hidden;
 
-  p {
-    color: var(--black);
-  }
-  #label {
-    color: var(--gray-500);
-  }
+  width: 107px;
+
+  color: var(--black);
+  white-space: nowrap;
+  text-overflow: ellipsis;
+`;
+const SGrayB3 = styled(SB3)`
+  color: var(--gray-500);
 `;
 
 export default FundingComponent;

--- a/src/components/common/ModalComponent.jsx
+++ b/src/components/common/ModalComponent.jsx
@@ -84,8 +84,8 @@ const SBackgroundDiv = styled.div`
   left: 0;
   z-index: 9999;
 
-  width: 100vw;
-  height: 100vh;
+  width: 100svw;
+  height: 100svh;
 
   background-color: #00000066;
 `;

--- a/src/components/common/NavComponent.jsx
+++ b/src/components/common/NavComponent.jsx
@@ -112,9 +112,9 @@ const SCircleWrapper = styled.div`
   width: 64px;
   height: 64px;
 
-  background-color: var(--jade-pri);
   border-radius: 50%;
   border: 8px solid var(--white);
+  background-color: var(--jade-pri);
 `;
 
 export default NavComponent;

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -88,6 +88,7 @@ const PasswordComponent = ({
         ))}
       </SPasswordInputContainer>
       {errorMessage && <SErrorSpan>{errorMessage}</SErrorSpan>}
+      {/* ButtonComponent 사용하기 */}
       <SBtn
         type='submit'
         disabled={!isPasswordComplete}

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -87,15 +87,15 @@ const PasswordComponent = ({
           />
         ))}
       </SPasswordInputContainer>
-      {errorMessage && <STextWrapper>{errorMessage}</STextWrapper>}
-      <SSecondaryButton
+      {errorMessage && <SErrorSpan>{errorMessage}</SErrorSpan>}
+      <SBtn
         type='submit'
         disabled={!isPasswordComplete}
         color={color}
         onClick={() => handlePasswordSubmit()}
       >
         완료
-      </SSecondaryButton>
+      </SBtn>
     </BottomSheetComponent>
   );
 };
@@ -137,7 +137,7 @@ const SPasswordInput = styled.input`
   font-weight: 500;
   text-align: center;
 `;
-const SSecondaryButton = styled.button`
+const SBtn = styled.button`
   width: 335px;
   height: 48px;
   margin-left: 24px;
@@ -154,7 +154,7 @@ const SSecondaryButton = styled.button`
 
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 `;
-const STextWrapper = styled.p`
+const SErrorSpan = styled.span`
   color: var(--red);
   text-align: center;
   margin-bottom: 35px;

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -158,7 +158,7 @@ const SPasswordInput = styled.input`
 `;
 const SBtn = styled.button`
   width: 335px;
-  height: 48px;
+  height: 56px;
 
   border-radius: 40px;
   background-color: ${({ disabled, color }) => {

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -24,6 +24,7 @@ const PasswordComponent = ({
   name,
   passwordExact,
   color,
+  ...props
 }) => {
   const [password, setPassword] = useState(['', '', '', '']);
   const inputRefs = useRef([]);
@@ -65,6 +66,7 @@ const PasswordComponent = ({
     <BottomSheetComponent
       closeButton='cross'
       setBottomSheetShow={setBottomSheetShow}
+      {...props}
     >
       <SBottomSheetContainer>
         <STextContainer>

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -88,9 +88,8 @@ const PasswordComponent = ({
         ))}
       </SPasswordInputContainer>
       {errorMessage && <STextWrapper>{errorMessage}</STextWrapper>}
-
       <SSecondaryButton
-        type='button'
+        type='submit'
         disabled={!isPasswordComplete}
         color={color}
         onClick={() => handlePasswordSubmit()}

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -129,11 +129,13 @@ const SPasswordInputContainer = styled.div`
 const SPasswordInput = styled.input`
   width: 56px;
   height: 80px;
-  font-size: 16px;
 
   border-radius: 4px;
   background-color: var(--gray-100);
 
+  color: var(--black);
+  font-size: 30px;
+  font-weight: 500;
   text-align: center;
 `;
 const SSecondaryButton = styled.button`

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -1,16 +1,16 @@
 /*
-  부모 컴포넌트에 패스워드가 유효하다면 어느 창으로 이동할지 passwordIsValid()로 설정해주시면 됩니다.
-   function passwordIsValid() {
-      navigate('/');
-  }
-  {bottomSheetShow && (
-    <PasswordComponent
-      setBottomSheetShow={setBottomSheetShow}
-      passwardExact={'1234'}
-      validPassword={() => passwordIsValid()}
-      color='orange'
-    />
-  )}
+부모 컴포넌트에 패스워드가 유효하다면 어느 창으로 이동할지 passwordIsValid()로 설정해주시면 됩니다.
+function passwordIsValid() {
+  navigate('/');
+}
+{bottomSheetShow && (
+  <PasswordComponent
+    setBottomSheetShow={setBottomSheetShow}
+    passwardExact={'1234'}
+    validPassword={() => passwordIsValid()}
+    color='orange'
+  />
+)}
 */
 
 import styled from 'styled-components';

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -65,7 +65,6 @@ const PasswordComponent = ({
     <BottomSheetComponent
       closeButton='cross'
       setBottomSheetShow={setBottomSheetShow}
-      style={{ position: 'absolute' }}
     >
       <STextContainer>
         <h4>비밀번호 입력</h4>
@@ -105,37 +104,29 @@ const PasswordComponent = ({
 const STextContainer = styled.div`
   display: flex;
   flex-direction: column;
-  width: 100%;
   margin-left: 24px;
   margin-right: 24px;
   h4 {
     margin-bottom: 12px;
     color: black;
     font-size: 20px;
-    font-style: normal;
     font-weight: 600;
-    line-height: 140%;
   }
   p {
     color: var(--gray-500);
     font-size: 14px;
-    font-style: normal;
     font-weight: 500;
-    line-height: 140%;
   }
 `;
 const SPasswordInputContainer = styled.div`
   display: flex;
-  justify-content: center;
   gap: 8px;
-  width: 100%;
   margin-top: 32px;
   margin-bottom: 12px;
 `;
 const SPasswordInput = styled.input`
   width: 56px;
   height: 80px;
-  border: none;
   font-size: 16px;
   border-radius: 4px;
   background: var(--gray-100);
@@ -152,7 +143,6 @@ const SSecondaryButton = styled.button`
   color: white;
   font-size: 16px;
   font-weight: 600;
-  border: none;
   border-radius: 40px;
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 `;
@@ -162,7 +152,6 @@ const STextWrapper = styled.p`
   margin-bottom: 35px;
 
   font-size: 14px;
-  font-style: normal;
   font-weight: 500;
   line-height: 120%;
 `;

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -106,12 +106,14 @@ const STextContainer = styled.div`
   flex-direction: column;
   margin-left: 24px;
   margin-right: 24px;
+
   h4 {
     margin-bottom: 12px;
-    color: black;
+    color: var(--black);
     font-size: 20px;
     font-weight: 600;
   }
+
   p {
     color: var(--gray-500);
     font-size: 14px;
@@ -128,22 +130,27 @@ const SPasswordInput = styled.input`
   width: 56px;
   height: 80px;
   font-size: 16px;
+
   border-radius: 4px;
   background: var(--gray-100);
+
   text-align: center;
 `;
 const SSecondaryButton = styled.button`
   width: 335px;
   height: 48px;
   margin-left: 24px;
+
+  border-radius: 40px;
   background-color: ${({ disabled, color }) => {
     if (disabled) return 'var(--gray-100)';
     return color === 'orange' ? 'var(--orange-pri)' : 'var(--jade-pri)';
   }};
+
   color: white;
   font-size: 16px;
   font-weight: 600;
-  border-radius: 40px;
+
   cursor: ${({ disabled }) => (disabled ? 'not-allowed' : 'pointer')};
 `;
 const STextWrapper = styled.p`

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -66,49 +66,62 @@ const PasswordComponent = ({
       closeButton='cross'
       setBottomSheetShow={setBottomSheetShow}
     >
-      <STextContainer>
-        <h4>비밀번호 입력</h4>
-        {name ? (
-          <p>펀딩을 개설한 {name}님께 비밀번호를 요청하세요</p>
-        ) : (
-          <p>4자리 숫자를 입력해 주세요</p>
-        )}
-      </STextContainer>
-      <SPasswordInputContainer>
-        {password.map((digit, index) => (
-          <SPasswordInput
-            key={index}
-            type='text'
-            maxLength='1'
-            value={digit}
-            onChange={(e) => handlePasswordChange(e, index)}
-            ref={(el) => (inputRefs.current[index] = el)}
-            onKeyDown={(e) => handleKeyDown(e, index)}
-          />
-        ))}
-      </SPasswordInputContainer>
-      {errorMessage && <SErrorSpan>{errorMessage}</SErrorSpan>}
-      {/* ButtonComponent 사용하기 */}
-      <SBtn
-        type='submit'
-        disabled={!isPasswordComplete}
-        color={color}
-        onClick={() => handlePasswordSubmit()}
-      >
-        완료
-      </SBtn>
+      <SBottomSheetContainer>
+        <STextContainer>
+          <h4>비밀번호 입력</h4>
+          {name ? (
+            <p>펀딩을 개설한 {name}님께 비밀번호를 요청하세요</p>
+          ) : (
+            <p>4자리 숫자를 입력해 주세요</p>
+          )}
+        </STextContainer>
+        <SForm>
+          <SPasswordInputContainer>
+            {password.map((digit, index) => (
+              <SPasswordInput
+                key={index}
+                type='text'
+                maxLength='1'
+                value={digit}
+                onChange={(e) => handlePasswordChange(e, index)}
+                ref={(el) => (inputRefs.current[index] = el)}
+                onKeyDown={(e) => handleKeyDown(e, index)}
+              />
+            ))}
+          </SPasswordInputContainer>
+          {errorMessage && <SErrorSpan>{errorMessage}</SErrorSpan>}
+          {/* ButtonComponent 사용하기 */}
+          <SBtn
+            type='submit'
+            disabled={!isPasswordComplete}
+            color={color}
+            onClick={() => handlePasswordSubmit()}
+          >
+            완료
+          </SBtn>
+        </SForm>
+      </SBottomSheetContainer>
     </BottomSheetComponent>
   );
 };
 
+const SBottomSheetContainer = styled.div`
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+
+  padding: 26px 20px 24px;
+  gap: 32px;
+`;
 const STextContainer = styled.div`
   display: flex;
-  margin-left: 24px;
-  margin-right: 24px;
   flex-flow: column nowrap;
+  align-self: flex-start;
+
+  margin-left: 4px;
+  gap: 12px;
 
   h4 {
-    margin-bottom: 12px;
     color: var(--black);
     font-size: 20px;
     font-weight: 600;
@@ -120,11 +133,16 @@ const STextContainer = styled.div`
     font-weight: 500;
   }
 `;
+const SForm = styled.form`
+  display: flex;
+  flex-flow: column nowrap;
+  align-items: center;
+
+  gap: 64px;
+`;
 const SPasswordInputContainer = styled.div`
   display: flex;
   gap: 8px;
-  margin-top: 32px;
-  margin-bottom: 12px;
 `;
 const SPasswordInput = styled.input`
   width: 56px;
@@ -141,7 +159,6 @@ const SPasswordInput = styled.input`
 const SBtn = styled.button`
   width: 335px;
   height: 48px;
-  margin-left: 24px;
 
   border-radius: 40px;
   background-color: ${({ disabled, color }) => {

--- a/src/components/common/PasswordComponent.jsx
+++ b/src/components/common/PasswordComponent.jsx
@@ -103,9 +103,9 @@ const PasswordComponent = ({
 
 const STextContainer = styled.div`
   display: flex;
-  flex-direction: column;
   margin-left: 24px;
   margin-right: 24px;
+  flex-flow: column nowrap;
 
   h4 {
     margin-bottom: 12px;
@@ -132,7 +132,7 @@ const SPasswordInput = styled.input`
   font-size: 16px;
 
   border-radius: 4px;
-  background: var(--gray-100);
+  background-color: var(--gray-100);
 
   text-align: center;
 `;

--- a/src/components/common/TagComponent.jsx
+++ b/src/components/common/TagComponent.jsx
@@ -12,9 +12,7 @@ const TagComponent = ({ text, color = 'gray' }) => {
   return <SLayout $color={colorOption[color]}>{text}</SLayout>;
 };
 
-const SLayout = styled.span`
-  width: fit-content;
-  height: fit-content;
+const SLayout = styled.div`
   padding: 4px 8px;
 
   border-radius: 20px;

--- a/src/components/common/TagComponent.jsx
+++ b/src/components/common/TagComponent.jsx
@@ -3,30 +3,25 @@
 
 import styled from 'styled-components';
 
-const TagComponent = ({ text, color }) => {
-  const btnColor = {
+const TagComponent = ({ text, color = 'gray' }) => {
+  const colorOption = {
     orange: ['var(--orange-sec)', 'var(--orange-pri)'],
     jade: ['var(--jade-sec)', 'var(--jade-pri)'],
     gray: ['var(--gray-200)', 'var(--gray-500)'],
   };
-  return <SLayout color={btnColor[color]}>{text}</SLayout>;
+  return <SLayout $color={colorOption[color]}>{text}</SLayout>;
 };
 
-const SLayout = styled.div`
-  display: inline-flex;
-  justify-content: center;
-  align-items: center;
-
+const SLayout = styled.span`
+  width: fit-content;
+  height: fit-content;
   padding: 4px 8px;
 
   border-radius: 20px;
-  background-color: ${(props) =>
-    props.color ? props.color[0] : 'var(--gray-100)'};
+  background-color: ${({ $color }) => $color[0]};
 
-  text-align: center;
-  color: ${(props) => (props.color ? props.color[1] : 'var(--gray-400)')};
+  color: ${({ $color }) => $color[1]};
   font-size: 12px;
-  font-style: normal;
   font-weight: 600;
   line-height: 120%;
 `;

--- a/src/pages/Friend/FriendPage.jsx
+++ b/src/pages/Friend/FriendPage.jsx
@@ -157,6 +157,7 @@ const FriendPage = () => {
                 btnInfo={
                   email ? { text: '완료', color: 'orange' } : { text: '완료' }
                 }
+                disabled={!email}
               />
             </SForm>
           </SBottomSheetContainer>

--- a/src/pages/Friend/FriendPage.jsx
+++ b/src/pages/Friend/FriendPage.jsx
@@ -14,9 +14,8 @@ import NavComponent from '../../components/common/NavComponent.jsx';
 const FriendPage = () => {
   // 친구 페이지 데이터
   const [friendList, setFriendList] = useState([]);
-  const [carouselFriendList, setCarouselFriendList] = useState(null);
-  const chopedCarouselFriendList =
-    carouselFriendList && arrayChop(carouselFriendList, 2);
+  const [carouselFriendList, setCarouselFriendList] = useState([]);
+  const chopedCarouselFriendList = arrayChop(carouselFriendList, 2).slice(0, 3);
   // 바텀시트 관련
   const [bottomSheetShow, setBottomSheetShow] = useState(false);
   const [email, setEmail] = useState('');
@@ -68,7 +67,7 @@ const FriendPage = () => {
   return (
     <SLayout>
       <SH1 as='header'>친구</SH1>
-      {carouselFriendList && (
+      {carouselFriendList.length > 0 && (
         <SSection>
           <ST1>나에게 선물한 친구</ST1>
           <CarouselComponent

--- a/src/pages/Friend/FriendPage.jsx
+++ b/src/pages/Friend/FriendPage.jsx
@@ -182,7 +182,6 @@ const SH3 = styled.h3`
   color: var(--black);
   font-size: 20px;
   font-weight: 600;
-  line-height: 140%;
 `;
 const ST1 = styled.h1`
   color: var(--black);
@@ -276,13 +275,15 @@ const SBottomSheetContainer = styled.div`
   flex-flow: column nowrap;
   align-items: center;
 
+  padding: 26px 20px 24px;
   gap: 32px;
 `;
 const STextContainer = styled.div`
   display: flex;
   flex-flow: column nowrap;
+  align-self: flex-start;
 
-  width: 327px;
+  margin-left: 4px;
   gap: 12px;
 `;
 const SForm = styled.form`
@@ -290,8 +291,7 @@ const SForm = styled.form`
   flex-flow: column nowrap;
   align-items: center;
 
-  width: fit-content;
-  gap: 60px;
+  gap: 80px;
 `;
 const SInput = styled.input`
   width: 327px;

--- a/src/pages/FundingInfo/FundingInfoPage.jsx
+++ b/src/pages/FundingInfo/FundingInfoPage.jsx
@@ -158,6 +158,7 @@ const FundingInfoPage = () => {
       )}
       {funding === 'pre' && bottomSheetShow && (
         <PasswordComponent
+          action='back' // 바텀시트 cross 버튼 클릭 시 뒤로가기 + background 이벤트리스너 비활성화
           passwordExact={getPassword}
           setBottomSheetShow={setBottomSheetShow}
           validPassword={() => setBottomSheetShow(false)}

--- a/src/pages/FundingJoin/IndexPage.jsx
+++ b/src/pages/FundingJoin/IndexPage.jsx
@@ -1,7 +1,62 @@
-import styled from 'styled-components';
+import { createContext, useContext, useState } from 'react';
+import FundingJoinPage from './FundingJoinPage';
+import CompletePage from './CompletePage';
+
+// 데이터 관리
+const DataContext = createContext();
+const DataProvider = ({ children }) => {
+  // 데이터
+
+  return (
+    <DataContext.Provider
+      value={
+        {
+          // 데이터
+        }
+      }
+    >
+      {children}
+    </DataContext.Provider>
+  );
+};
+
+// 페이지 관리
+const PageContext = createContext();
+const PageProvider = ({ children }) => {
+  const [currentPage, setCurrentPage] = useState('FundingJoinPage');
+
+  return (
+    <PageContext.Provider value={{ currentPage, setCurrentPage }}>
+      {children}
+    </PageContext.Provider>
+  );
+};
+const PageRenderer = () => {
+  const { currentPage } = useContext(PageContext);
+
+  switch (currentPage) {
+    case 'FundingJoinPage':
+      return <FundingJoinPage />;
+    case '결제랜딩페이지':
+      // 랜딩 페이지 만들 때 SpinnerComponent 쓰세요 빙글빙글 돌아갑니다
+      return;
+    case 'CompletePage':
+      // 결제 후에 펀딩 참여 POST
+      return <CompletePage />;
+    default:
+      return <HomePage />;
+  }
+};
 
 const IndexPage = () => {
-  return <div></div>;
+  return (
+    <DataProvider>
+      <PageProvider>
+        <PageRenderer />
+      </PageProvider>
+    </DataProvider>
+  );
 };
 
 export default IndexPage;
+export { DataContext, PageContext };

--- a/src/pages/FundingOpen/FundingSetPage.jsx
+++ b/src/pages/FundingOpen/FundingSetPage.jsx
@@ -2,7 +2,7 @@ import styled from 'styled-components';
 import DaumPostcode from 'react-daum-postcode';
 import { useState, useEffect, useContext } from 'react';
 import { useForm } from 'react-hook-form';
-import { PageContext } from './IndexPage';
+import { DataContext, PageContext } from './IndexPage';
 import BackHeaderComponent from '../../components/common/BackHeaderComponent';
 import ButtonComponent from '../../components/common/ButtonComponent';
 import BottomBackgroundComponent from '../../components/common/BottomBackgroundComponent';
@@ -10,6 +10,8 @@ import BottomBackgroundComponent from '../../components/common/BottomBackgroundC
 const FundingSetPage = () => {
   const { setCurrentPage } = useContext(PageContext);
   const [currentDate, setCurrentDate] = useState('');
+  const { setFundingData } = useContext(DataContext);
+
   const [isOpen, setIsOpen] = useState(false);
   const [isAddressOpen, setIsAddressOpen] = useState(false);
   const [isButtonActive, setIsButtonActive] = useState(false);
@@ -52,6 +54,16 @@ const FundingSetPage = () => {
     setIsOpen((prevOpenState) => !prevOpenState);
   };
   const handleFormSubmit = () => {
+    setFundingData({
+      fundingTitle: null,
+      fundingContent: null,
+      fundingEndDate: null,
+      name: null,
+      phoneNumber: null,
+      addressNumber: null,
+      addressDetail1: null,
+      addressDetail2: null,
+    });
     setCurrentPage('PasswordSetPage');
   };
 

--- a/src/pages/FundingOpen/FundingSetPage.jsx
+++ b/src/pages/FundingOpen/FundingSetPage.jsx
@@ -24,8 +24,8 @@ const FundingSetPage = () => {
   } = useForm({
     defaultValues: {
       title: '',
-      detail: '',
-      date: '',
+      content: '',
+      endDate: '',
       name: '',
       phoneNumber: '',
       addressNumber: '',
@@ -35,7 +35,7 @@ const FundingSetPage = () => {
     mode: 'onChange',
   });
   const title = watch('title');
-  const date = watch('date');
+  const endDate = watch('endDate');
   const name = watch('name');
   const phoneNumber = watch('phoneNumber');
 
@@ -67,11 +67,12 @@ const FundingSetPage = () => {
     setCurrentDate(today);
     setValue('currentDate', today);
   }, [setValue]);
+
   useEffect(() => {
     setIsButtonActive(
-      title !== '' && date !== '' && name !== '' && phoneNumber != '',
+      title !== '' && endDate !== '' && name !== '' && phoneNumber != '',
     );
-  }, [title, date, name, phoneNumber]);
+  }, [title, endDate, name, phoneNumber]);
 
   return (
     <SLayout>
@@ -99,12 +100,12 @@ const FundingSetPage = () => {
           )}
         </fieldset>
         <fieldset>
-          <SLabel htmlFor='detail'>
+          <SLabel htmlFor='content'>
             <p>펀딩 소개</p>
           </SLabel>
           <STextInput
-            id='detail'
-            {...register('detail', {
+            id='content'
+            {...register('content', {
               required: false,
               maxLength: {
                 value: 120,
@@ -113,8 +114,8 @@ const FundingSetPage = () => {
             })}
             placeholder='펀딩을 소개해 주세요'
           />
-          {errors.detail && (
-            <SWarningWrapper>{errors.detail.message}</SWarningWrapper>
+          {errors.content && (
+            <SWarningWrapper>{errors.content.message}</SWarningWrapper>
           )}
         </fieldset>
         <fieldset>
@@ -131,7 +132,7 @@ const FundingSetPage = () => {
               readOnly
             />
             <SDateInput
-              {...register('date', {
+              {...register('endDate', {
                 required: '날짜를 입력해주세요',
                 validate: (value) =>
                   value >= getValues('currentDate') ||
@@ -140,8 +141,8 @@ const FundingSetPage = () => {
               type='date'
             />
           </SDateContainer>
-          {errors.date && (
-            <SWarningWrapper>{errors.date.message}</SWarningWrapper>
+          {errors.endDate && (
+            <SWarningWrapper>{errors.endDate.message}</SWarningWrapper>
           )}
         </fieldset>
         <fieldset>

--- a/src/pages/FundingOpen/FundingSetPage.jsx
+++ b/src/pages/FundingOpen/FundingSetPage.jsx
@@ -1,7 +1,6 @@
 import styled from 'styled-components';
 import DaumPostcode from 'react-daum-postcode';
 import { useState, useEffect, useContext } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import { PageContext } from './IndexPage';
 import BackHeaderComponent from '../../components/common/BackHeaderComponent';
@@ -13,7 +12,6 @@ const FundingSetPage = () => {
   const [currentDate, setCurrentDate] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [isAddressOpen, setIsAddressOpen] = useState(false);
-  const navigate = useNavigate();
   const [isButtonActive, setIsButtonActive] = useState(false);
   const {
     register,

--- a/src/pages/FundingOpen/FundingSetPage.jsx
+++ b/src/pages/FundingOpen/FundingSetPage.jsx
@@ -1,13 +1,15 @@
 import styled from 'styled-components';
 import DaumPostcode from 'react-daum-postcode';
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useContext } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
+import { PageContext } from './IndexPage';
 import BackHeaderComponent from '../../components/common/BackHeaderComponent';
 import ButtonComponent from '../../components/common/ButtonComponent';
 import BottomBackgroundComponent from '../../components/common/BottomBackgroundComponent';
 
 const FundingSetPage = () => {
+  const { setCurrentPage } = useContext(PageContext);
   const [currentDate, setCurrentDate] = useState('');
   const [isOpen, setIsOpen] = useState(false);
   const [isAddressOpen, setIsAddressOpen] = useState(false);
@@ -51,6 +53,9 @@ const FundingSetPage = () => {
   const toggleHandler = () => {
     setIsOpen((prevOpenState) => !prevOpenState);
   };
+  const handleFormSubmit = () => {
+    setCurrentPage('PasswordSetPage');
+  };
 
   useEffect(() => {
     const today = new Date().toISOString().split('T')[0];
@@ -65,8 +70,8 @@ const FundingSetPage = () => {
 
   return (
     <SLayout>
-      <BackHeaderComponent />
-      <SForm onSubmit={handleSubmit(onSubmit)}>
+      <BackHeaderComponent onClick={() => setCurrentPage('GiftAddPage')} />
+      <SForm onSubmit={handleFormSubmit}>
         <fieldset>
           <SLabel htmlFor='title'>
             <p>제목</p>

--- a/src/pages/FundingOpen/FundingSetPage.jsx
+++ b/src/pages/FundingOpen/FundingSetPage.jsx
@@ -199,20 +199,20 @@ const FundingSetPage = () => {
             <SWarningWrapper>{errors.address.message}</SWarningWrapper>
           )}
         </fieldset>
+        <BottomBackgroundComponent
+          Button={
+            <ButtonComponent
+              type='submit'
+              disabled={!isValid}
+              btnInfo={{
+                text: '다음',
+                color: isValid ? 'jade' : 'gray',
+                width: '335px',
+              }}
+            />
+          }
+        />
       </SForm>
-      <BottomBackgroundComponent
-        Button={
-          <ButtonComponent
-            type='submit'
-            disabled={!isValid}
-            btnInfo={{
-              text: '다음',
-              color: isValid ? 'jade' : 'gray',
-              width: '335px',
-            }}
-          />
-        }
-      />
       {isOpen && (
         <SPostcodeContainer>
           <DaumPostcode

--- a/src/pages/FundingOpen/FundingSetPage.jsx
+++ b/src/pages/FundingOpen/FundingSetPage.jsx
@@ -1,11 +1,11 @@
-import React, { useState, useEffect } from 'react';
 import styled from 'styled-components';
+import DaumPostcode from 'react-daum-postcode';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import { useForm } from 'react-hook-form';
 import BackHeaderComponent from '../../components/common/BackHeaderComponent';
 import ButtonComponent from '../../components/common/ButtonComponent';
 import BottomBackgroundComponent from '../../components/common/BottomBackgroundComponent';
-import DaumPostcode from 'react-daum-postcode';
 
 const FundingSetPage = () => {
   const [currentDate, setCurrentDate] = useState('');
@@ -33,34 +33,30 @@ const FundingSetPage = () => {
     },
     mode: 'onChange',
   });
-
-  useEffect(() => {
-    const today = new Date().toISOString().split('T')[0];
-    setCurrentDate(today);
-    setValue('currentDate', today);
-  }, [setValue]);
+  const title = watch('title');
+  const date = watch('date');
+  const name = watch('name');
+  const phoneNumber = watch('phoneNumber');
 
   const onSubmit = (data) => {
     navigate('/password-set', { state: { formData: data } });
     console.log(data);
   };
-
   const completeHandler = (data) => {
     setValue('addressNumber', data.zonecode);
     setValue('addressDetail1', data.address);
     setIsOpen(false);
     setIsAddressOpen(true);
   };
-
   const toggleHandler = () => {
     setIsOpen((prevOpenState) => !prevOpenState);
   };
 
-  const title = watch('title');
-  const date = watch('date');
-  const name = watch('name');
-  const phoneNumber = watch('phoneNumber');
-
+  useEffect(() => {
+    const today = new Date().toISOString().split('T')[0];
+    setCurrentDate(today);
+    setValue('currentDate', today);
+  }, [setValue]);
   useEffect(() => {
     setIsButtonActive(
       title !== '' && date !== '' && name !== '' && phoneNumber != '',

--- a/src/pages/FundingOpen/FundingSetPage.jsx
+++ b/src/pages/FundingOpen/FundingSetPage.jsx
@@ -9,7 +9,6 @@ import BottomBackgroundComponent from '../../components/common/BottomBackgroundC
 
 const FundingSetPage = () => {
   const { setCurrentPage } = useContext(PageContext);
-  const [currentDate, setCurrentDate] = useState('');
   const { setFundingData } = useContext(DataContext);
 
   const [isOpen, setIsOpen] = useState(false);
@@ -40,10 +39,6 @@ const FundingSetPage = () => {
   const name = watch('name');
   const phoneNumber = watch('phoneNumber');
 
-  const onSubmit = (data) => {
-    navigate('/password-set', { state: { formData: data } });
-    console.log(data);
-  };
   const completeHandler = (data) => {
     setValue('addressNumber', data.zonecode);
     setValue('addressDetail1', data.address);

--- a/src/pages/FundingOpen/GiftAddPage.jsx
+++ b/src/pages/FundingOpen/GiftAddPage.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { useState, useContext } from 'react';
-import { PageContext } from './IndexPage';
+import { DataContext, PageContext } from './IndexPage';
 import BackHeaderComponent from '../../components/common/BackHeaderComponent';
 import BottomBackgroundComponent from '../../components/common/BottomBackgroundComponent';
 import FundingPercentage from '../../components/FundingInfo/FundingPercentage';
@@ -16,6 +16,8 @@ const giftList = [
 
 const GiftAddPage = () => {
   const { setCurrentPage } = useContext(PageContext);
+  const { setGiftData } = useContext(DataContext);
+
   const [isTrue, setIsTrue] = useState(true);
 
   const Btn = (

--- a/src/pages/FundingOpen/GiftAddPage.jsx
+++ b/src/pages/FundingOpen/GiftAddPage.jsx
@@ -19,13 +19,12 @@ const GiftAddPage = () => {
   const Btn = (
     <SBtnContainer>
       <ButtonComponent
-        btnInfo={{ color: 'orange', text: '새로운 선물 추가하기' }}
+        btnInfo={{ text: '새로운 선물 추가하기', color: 'orange' }}
       />
-      {isTrue ? (
-        <ButtonComponent btnInfo={{ color: 'jade', text: '펀딩 만들기' }} />
-      ) : (
-        <ButtonComponent btnInfo={{ text: '펀딩 만들기' }} />
-      )}
+      <ButtonComponent
+        btnInfo={{ text: '펀딩 만들기', color: isTrue ? 'jade' : 'gray' }}
+        disabled={!isTrue}
+      />
     </SBtnContainer>
   );
 

--- a/src/pages/FundingOpen/GiftAddPage.jsx
+++ b/src/pages/FundingOpen/GiftAddPage.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { PageContext } from './IndexPage';
 import BackHeaderComponent from '../../components/common/BackHeaderComponent';
 import BottomBackgroundComponent from '../../components/common/BottomBackgroundComponent';
 import FundingPercentage from '../../components/FundingInfo/FundingPercentage';
@@ -14,23 +15,26 @@ const giftList = [
 ];
 
 const GiftAddPage = () => {
+  const { setCurrentPage } = useContext(PageContext);
   const [isTrue, setIsTrue] = useState(true);
 
   const Btn = (
     <SBtnContainer>
       <ButtonComponent
         btnInfo={{ text: '새로운 선물 추가하기', color: 'orange' }}
+        onClick={() => setCurrentPage('GiftSetPage')}
       />
       <ButtonComponent
         btnInfo={{ text: '펀딩 만들기', color: isTrue ? 'jade' : 'gray' }}
         disabled={!isTrue}
+        onClick={() => setCurrentPage('FundingSetPage')}
       />
     </SBtnContainer>
   );
 
   return (
     <SLayout>
-      <BackHeaderComponent />
+      <BackHeaderComponent onClick={() => setCurrentPage('GiftSetPage-back')} />
       <SContainer>
         <STitleWrapper>선물을 추가했어요!</STitleWrapper>
         <FundingPercentage

--- a/src/pages/FundingOpen/GiftSetPage.jsx
+++ b/src/pages/FundingOpen/GiftSetPage.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
-import { useState } from 'react';
+import { useState, useContext } from 'react';
+import { PageContext } from './IndexPage';
 import BackHeaderComponent from '../../components/common/BackHeaderComponent';
 import PriceInputComponent from '../../components/common/PriceInputComponent';
 import BottomBackgroundComponent from '../../components/common/BottomBackgroundComponent';
@@ -7,6 +8,7 @@ import ButtonComponent from '../../components/common/ButtonComponent';
 import icn_plus from '../../assets/FungingOpen/icn_plus.svg';
 
 const GiftSetPage = () => {
+  const { setCurrentPage } = useContext(PageContext);
   const [price, setPrice] = useState(null);
   const [url, setUrl] = useState(null);
   const [imageFile, setImageFile] = useState(null);
@@ -22,11 +24,14 @@ const GiftSetPage = () => {
       setImagePreview(URL.createObjectURL(file));
     }
   };
+  const handleFormSubmit = () => {
+    setCurrentPage('GiftAddPage');
+  };
 
   return (
     <SLayout>
       <BackHeaderComponent />
-      <SForm>
+      <SForm onSubmit={handleFormSubmit}>
         <fieldset>
           <SLegend>가격</SLegend>
           <PriceInputComponent

--- a/src/pages/FundingOpen/GiftSetPage.jsx
+++ b/src/pages/FundingOpen/GiftSetPage.jsx
@@ -22,20 +22,7 @@ const GiftSetPage = ({
   const [price, setPrice] = useState(lastGiftData.price);
   const [url, setUrl] = useState(lastGiftData.giftUrl);
   const [imageFile, setImageFile] = useState(lastImageData);
-  const [imagePreview, setImagePreview] = useState(
-    lastImageData ? URL.createObjectURL(lastImageData) : null,
-  );
 
-  const handleUrlChange = (event) => {
-    setUrl(event.target.value);
-  };
-  const handleImageChange = (event) => {
-    const file = event.target.files[0];
-    if (file) {
-      setImageFile(file);
-      setImagePreview(URL.createObjectURL(file));
-    }
-  };
   const handleFormSubmit = () => {
     if (lastGiftData) {
       setGiftData((prevItems) => [
@@ -94,13 +81,13 @@ const GiftSetPage = ({
             placeholder='상품 링크를 붙여 넣어 주세요'
             value={url}
             required
-            onChange={handleUrlChange}
+            onChange={(event) => setUrl(event.target.value)}
           />
         </fieldset>
         <fieldset>
           <SLegend>사진</SLegend>
           <SImageLabel htmlFor='gift-image'>
-            {imagePreview && <SImg src={imagePreview} />}
+            {imageFile && <SImg src={URL.createObjectURL(imageFile)} />}
           </SImageLabel>
           <SImageInput
             type='file'
@@ -109,7 +96,9 @@ const GiftSetPage = ({
             id='gift-image'
             placeholder='+'
             required
-            onChange={handleImageChange}
+            onChange={(event) => {
+              event.target.files[0] && setImageFile(event.target.files[0]);
+            }}
           />
         </fieldset>
         <BottomBackgroundComponent
@@ -117,6 +106,7 @@ const GiftSetPage = ({
             <ButtonComponent
               type='submit'
               btnInfo={
+                // name && price && url && imageFile
                 price && url && imageFile
                   ? { text: '다음', color: 'jade', onClick: '' }
                   : { text: '선물 추가하기' }

--- a/src/pages/FundingOpen/GiftSetPage.jsx
+++ b/src/pages/FundingOpen/GiftSetPage.jsx
@@ -1,6 +1,6 @@
 import styled from 'styled-components';
 import { useState, useContext } from 'react';
-import { PageContext } from './IndexPage';
+import { DataContext, PageContext } from './IndexPage';
 import BackHeaderComponent from '../../components/common/BackHeaderComponent';
 import PriceInputComponent from '../../components/common/PriceInputComponent';
 import BottomBackgroundComponent from '../../components/common/BottomBackgroundComponent';
@@ -9,6 +9,9 @@ import icn_plus from '../../assets/FungingOpen/icn_plus.svg';
 
 const GiftSetPage = () => {
   const { setCurrentPage } = useContext(PageContext);
+  const { setGiftData, setImageData } = useContext(DataContext);
+
+  const [name, setName] = useState(null);
   const [price, setPrice] = useState(null);
   const [url, setUrl] = useState(null);
   const [imageFile, setImageFile] = useState(null);
@@ -25,6 +28,15 @@ const GiftSetPage = () => {
     }
   };
   const handleFormSubmit = () => {
+    setGiftData((prevData) => [
+      ...prevData,
+      {
+        giftName: name,
+        price: price,
+        giftUrl: url,
+      },
+    ]);
+    setImageData((prevItems) => [...prevItems, imageFile]);
     setCurrentPage('GiftAddPage');
   };
 

--- a/src/pages/FundingOpen/GiftSetPage.jsx
+++ b/src/pages/FundingOpen/GiftSetPage.jsx
@@ -7,15 +7,24 @@ import BottomBackgroundComponent from '../../components/common/BottomBackgroundC
 import ButtonComponent from '../../components/common/ButtonComponent';
 import icn_plus from '../../assets/FungingOpen/icn_plus.svg';
 
-const GiftSetPage = () => {
+const GiftSetPage = ({
+  lastGiftData = {
+    giftName: null,
+    price: null,
+    giftUrl: null,
+  },
+  lastImageData = null,
+}) => {
   const { setCurrentPage } = useContext(PageContext);
   const { setGiftData, setImageData } = useContext(DataContext);
 
-  const [name, setName] = useState(null);
-  const [price, setPrice] = useState(null);
-  const [url, setUrl] = useState(null);
-  const [imageFile, setImageFile] = useState(null);
-  const [imagePreview, setImagePreview] = useState(null);
+  const [name, setName] = useState(lastGiftData.giftName);
+  const [price, setPrice] = useState(lastGiftData.price);
+  const [url, setUrl] = useState(lastGiftData.giftUrl);
+  const [imageFile, setImageFile] = useState(lastImageData);
+  const [imagePreview, setImagePreview] = useState(
+    lastImageData ? URL.createObjectURL(lastImageData) : null,
+  );
 
   const handleUrlChange = (event) => {
     setUrl(event.target.value);
@@ -28,15 +37,34 @@ const GiftSetPage = () => {
     }
   };
   const handleFormSubmit = () => {
-    setGiftData((prevData) => [
-      ...prevData,
-      {
-        giftName: name,
-        price: price,
-        giftUrl: url,
-      },
-    ]);
-    setImageData((prevItems) => [...prevItems, imageFile]);
+    if (lastGiftData) {
+      setGiftData((prevItems) => [
+        // 마지막 아이템 삭제
+        ...prevItems.slice(prevItems.length - 2),
+        // 수정 아이템 저장
+        {
+          giftName: name,
+          price: price,
+          giftUrl: url,
+        },
+      ]);
+      setImageData((prevItems) => [
+        // 마지막 아이템 삭제
+        ...prevItems.slice(prevItems.length - 2),
+        // 수정 아이템 저장
+        imageFile,
+      ]);
+    } else {
+      setGiftData((prevItems) => [
+        ...prevItems,
+        {
+          giftName: name,
+          price: price,
+          giftUrl: url,
+        },
+      ]);
+      setImageData((prevItems) => [...prevItems, imageFile]);
+    }
     setCurrentPage('GiftAddPage');
   };
 
@@ -64,6 +92,7 @@ const GiftSetPage = () => {
             name='gift'
             id='gift-url'
             placeholder='상품 링크를 붙여 넣어 주세요'
+            value={url}
             required
             onChange={handleUrlChange}
           />

--- a/src/pages/FundingOpen/GiftSetPage.jsx
+++ b/src/pages/FundingOpen/GiftSetPage.jsx
@@ -66,19 +66,19 @@ const GiftSetPage = () => {
             onChange={handleImageChange}
           />
         </fieldset>
+        <BottomBackgroundComponent
+          Button={
+            <ButtonComponent
+              type='submit'
+              btnInfo={
+                price && url && imageFile
+                  ? { text: '다음', color: 'jade', onClick: '' }
+                  : { text: '선물 추가하기' }
+              }
+            />
+          }
+        />
       </SForm>
-      <BottomBackgroundComponent
-        Button={
-          <ButtonComponent
-            type='submit'
-            btnInfo={
-              price && url && imageFile
-                ? { text: '다음', color: 'jade', onClick: '' }
-                : { text: '선물 추가하기' }
-            }
-          />
-        }
-      />
     </SLayout>
   );
 };

--- a/src/pages/FundingOpen/IndexPage.jsx
+++ b/src/pages/FundingOpen/IndexPage.jsx
@@ -6,6 +6,7 @@ import PasswordSetPage from './PasswordSetPage';
 import CompletePage from './CompletePage';
 import HomePage from '../Home/HomePage';
 
+// 데이터 관리
 const DataContext = createContext();
 const DataProvider = ({ children }) => {
   const [fundingData, setFundingData] = useState({});
@@ -28,6 +29,7 @@ const DataProvider = ({ children }) => {
   );
 };
 
+// 페이지 관리
 const PageContext = createContext();
 const PageProvider = ({ children }) => {
   const [currentPage, setCurrentPage] = useState('GiftSetPage');
@@ -53,6 +55,7 @@ const PageRenderer = () => {
     case 'PasswordSetPage':
       return <PasswordSetPage />;
     case 'CompletePage':
+      // 펀딩 개설 POST
       return <CompletePage />;
     default:
       return <HomePage />;

--- a/src/pages/FundingOpen/IndexPage.jsx
+++ b/src/pages/FundingOpen/IndexPage.jsx
@@ -1,7 +1,49 @@
-import styled from 'styled-components';
+import { createContext, useContext, useState } from 'react';
+import GiftSetPage from './GiftSetPage';
+import GiftAddPage from './GiftAddPage';
+import FundingSetPage from './FundingSetPage';
+import PasswordSetPage from './PasswordSetPage';
+import CompletePage from './CompletePage';
+import HomePage from '../Home/HomePage';
+
+const PageContext = createContext();
+const PageProvider = ({ children }) => {
+  const [currentPage, setCurrentPage] = useState('GiftSetPage');
+
+  return (
+    <PageContext.Provider value={{ currentPage, setCurrentPage }}>
+      {children}
+    </PageContext.Provider>
+  );
+};
+const PageRenderer = () => {
+  const { currentPage } = useContext(PageContext);
+
+  switch (currentPage) {
+    case 'GiftSetPage':
+      return <GiftSetPage />;
+    case 'GiftSetPage-back':
+      return <GiftSetPage data={'마지막으로 추가한 선물'} />; //수정!!!!!
+    case 'GiftAddPage':
+      return <GiftAddPage />;
+    case 'FundingSetPage':
+      return <FundingSetPage />;
+    case 'PasswordSetPage':
+      return <PasswordSetPage />;
+    case 'CompletePage':
+      return <CompletePage />;
+    default:
+      return <HomePage />;
+  }
+};
 
 const IndexPage = () => {
-  return <div></div>;
+  return (
+    <PageProvider>
+      <PageRenderer />
+    </PageProvider>
+  );
 };
 
 export default IndexPage;
+export { PageContext };

--- a/src/pages/FundingOpen/IndexPage.jsx
+++ b/src/pages/FundingOpen/IndexPage.jsx
@@ -42,12 +42,18 @@ const PageProvider = ({ children }) => {
 };
 const PageRenderer = () => {
   const { currentPage } = useContext(PageContext);
+  const { giftData, imageData } = useContext(DataContext);
 
   switch (currentPage) {
     case 'GiftSetPage':
       return <GiftSetPage />;
     case 'GiftSetPage-back':
-      return <GiftSetPage data={'마지막으로 추가한 선물'} />; //수정!!!!!
+      return (
+        <GiftSetPage
+          lastGiftData={giftData[giftData.length - 1]}
+          lastImageData={imageData[imageData.length - 1]}
+        />
+      );
     case 'GiftAddPage':
       return <GiftAddPage />;
     case 'FundingSetPage':

--- a/src/pages/FundingOpen/IndexPage.jsx
+++ b/src/pages/FundingOpen/IndexPage.jsx
@@ -33,7 +33,6 @@ const DataProvider = ({ children }) => {
 const PageContext = createContext();
 const PageProvider = ({ children }) => {
   const [currentPage, setCurrentPage] = useState('GiftSetPage');
-  const { giftData, imageData } = useContext(DataContext);
 
   return (
     <PageContext.Provider value={{ currentPage, setCurrentPage }}>

--- a/src/pages/FundingOpen/IndexPage.jsx
+++ b/src/pages/FundingOpen/IndexPage.jsx
@@ -6,6 +6,28 @@ import PasswordSetPage from './PasswordSetPage';
 import CompletePage from './CompletePage';
 import HomePage from '../Home/HomePage';
 
+const DataContext = createContext();
+const DataProvider = ({ children }) => {
+  const [fundingData, setFundingData] = useState({});
+  const [giftData, setGiftData] = useState([]);
+  const [imageData, setImageData] = useState([]);
+
+  return (
+    <DataContext.Provider
+      value={{
+        fundingData,
+        setFundingData,
+        giftData,
+        setGiftData,
+        imageData,
+        setImageData,
+      }}
+    >
+      {children}
+    </DataContext.Provider>
+  );
+};
+
 const PageContext = createContext();
 const PageProvider = ({ children }) => {
   const [currentPage, setCurrentPage] = useState('GiftSetPage');
@@ -39,11 +61,13 @@ const PageRenderer = () => {
 
 const IndexPage = () => {
   return (
-    <PageProvider>
-      <PageRenderer />
-    </PageProvider>
+    <DataProvider>
+      <PageProvider>
+        <PageRenderer />
+      </PageProvider>
+    </DataProvider>
   );
 };
 
 export default IndexPage;
-export { PageContext };
+export { DataContext, PageContext };

--- a/src/pages/FundingOpen/PasswordSetPage.jsx
+++ b/src/pages/FundingOpen/PasswordSetPage.jsx
@@ -13,9 +13,9 @@ let newPassword = '';
 
 const PasswordSetPage = () => {
   const { setCurrentPage } = useContext(PageContext);
-  const [bottomSheetShow, setBottomSheetShow] = useState(false);
   const { setFundingData } = useContext(DataContext);
 
+  const [bottomSheetShow, setBottomSheetShow] = useState(false);
   const { register, handleSubmit, watch, reset } = useForm({
     defaultValues: {
       visibility: '',
@@ -23,13 +23,6 @@ const PasswordSetPage = () => {
     },
     mode: 'onChange',
   });
-
-  useEffect(() => {
-    if (!bottomSheetShow) {
-      reset();
-    }
-  }, [bottomSheetShow, reset]);
-
   const visibility = watch('visibility');
 
   const setPassword = (data) => {
@@ -37,14 +30,12 @@ const PasswordSetPage = () => {
     console.log(newPassword, visibility);
     navigate('/');
   };
-
   const isButtonDisabled = () => {
     if (visibility === 'public') {
       return false;
     }
     return true;
   };
-
   const handleFormSubmit = () => {
     setFundingData((prevData) => ({
       ...prevData,
@@ -53,6 +44,12 @@ const PasswordSetPage = () => {
     }));
     setCurrentPage('CompletePage');
   };
+
+  useEffect(() => {
+    if (!bottomSheetShow) {
+      reset();
+    }
+  }, [bottomSheetShow, reset]);
 
   return (
     <FormProvider>

--- a/src/pages/FundingOpen/PasswordSetPage.jsx
+++ b/src/pages/FundingOpen/PasswordSetPage.jsx
@@ -32,10 +32,6 @@ const PasswordSetPage = () => {
     }
   }, [bottomSheetShow, reset]);
 
-  const onSubmit = (data) => {
-    console.log('폼 제출', data);
-  };
-
   const visibility = watch('visibility');
 
   const setPassword = (data) => {

--- a/src/pages/FundingOpen/PasswordSetPage.jsx
+++ b/src/pages/FundingOpen/PasswordSetPage.jsx
@@ -16,15 +16,13 @@ const PasswordSetPage = () => {
   const [bottomSheetShow, setBottomSheetShow] = useState(false);
   const { setFundingData } = useContext(DataContext);
 
-  const methods = useForm({
+  const { register, handleSubmit, watch, reset } = useForm({
     defaultValues: {
       visibility: '',
       password: '',
     },
     mode: 'onChange',
   });
-
-  const { register, handleSubmit, watch, reset } = methods;
 
   useEffect(() => {
     if (!bottomSheetShow) {

--- a/src/pages/FundingOpen/PasswordSetPage.jsx
+++ b/src/pages/FundingOpen/PasswordSetPage.jsx
@@ -1,7 +1,7 @@
 import styled from 'styled-components';
 import { useEffect, useState, useContext } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
-import { PageContext } from './IndexPage';
+import { DataContext, PageContext } from './IndexPage';
 import BackHeaderComponent from '../../components/common/BackHeaderComponent';
 import ButtonComponent from '../../components/common/ButtonComponent';
 import BottomBackgroundComponent from '../../components/common/BottomBackgroundComponent';
@@ -14,6 +14,7 @@ let newPassword = '';
 const PasswordSetPage = () => {
   const { setCurrentPage } = useContext(PageContext);
   const [bottomSheetShow, setBottomSheetShow] = useState(false);
+  const { setFundingData } = useContext(DataContext);
 
   const methods = useForm({
     defaultValues: {
@@ -51,6 +52,11 @@ const PasswordSetPage = () => {
   };
 
   const handleFormSubmit = () => {
+    setFundingData((prevData) => ({
+      ...prevData,
+      visibility: null,
+      password: null,
+    }));
     setCurrentPage('CompletePage');
   };
 

--- a/src/pages/FundingOpen/PasswordSetPage.jsx
+++ b/src/pages/FundingOpen/PasswordSetPage.jsx
@@ -1,5 +1,4 @@
 import styled from 'styled-components';
-import { useNavigate } from 'react-router-dom';
 import { useEffect, useState, useContext } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
 import { PageContext } from './IndexPage';
@@ -15,8 +14,6 @@ let newPassword = '';
 const PasswordSetPage = () => {
   const { setCurrentPage } = useContext(PageContext);
   const [bottomSheetShow, setBottomSheetShow] = useState(false);
-
-  const navigate = useNavigate();
 
   const methods = useForm({
     defaultValues: {

--- a/src/pages/FundingOpen/PasswordSetPage.jsx
+++ b/src/pages/FundingOpen/PasswordSetPage.jsx
@@ -1,7 +1,8 @@
 import styled from 'styled-components';
-import { useEffect, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
+import { useEffect, useState, useContext } from 'react';
 import { useForm, FormProvider } from 'react-hook-form';
+import { PageContext } from './IndexPage';
 import BackHeaderComponent from '../../components/common/BackHeaderComponent';
 import ButtonComponent from '../../components/common/ButtonComponent';
 import BottomBackgroundComponent from '../../components/common/BottomBackgroundComponent';
@@ -12,6 +13,7 @@ import { ReactComponent as BlueLocker } from '../../assets/PasswordSet/icn_btn_y
 let newPassword = '';
 
 const PasswordSetPage = () => {
+  const { setCurrentPage } = useContext(PageContext);
   const [bottomSheetShow, setBottomSheetShow] = useState(false);
 
   const navigate = useNavigate();
@@ -51,11 +53,17 @@ const PasswordSetPage = () => {
     return true;
   };
 
+  const handleFormSubmit = () => {
+    setCurrentPage('CompletePage');
+  };
+
   return (
     <FormProvider>
       <SLayout>
-        <BackHeaderComponent />
-        <form onSubmit={handleSubmit(onSubmit)}>
+        <BackHeaderComponent
+          onClick={() => setCurrentPage('PasswordSetPage')}
+        />
+        <form onSubmit={handleFormSubmit}>
           <SFieldset>
             <SLegend>공개 여부</SLegend>
             <SRadioContainer>

--- a/src/pages/Home/HomePage.jsx
+++ b/src/pages/Home/HomePage.jsx
@@ -1,9 +1,17 @@
 import styled from 'styled-components';
+import { useEffect, useState } from 'react';
 import NavComponent from '../../components/common/NavComponent';
 import Calendar from '../../components/Home/Calendar';
+import FundingComponent from '../../components/common/FundingComponent';
 import icn_search from '../../assets/common/search.svg';
 
 const HomePage = () => {
+  const [possibleFundingList, setPossibleFundingList] = useState([]);
+
+  useEffect(() => {
+    setPossibleFundingList([]);
+  }, []);
+
   return (
     <SLayout>
       <section>
@@ -27,7 +35,11 @@ const HomePage = () => {
       </SSection>
       <SSection>
         <SH2>참여 가능한 펀딩</SH2>
-        {/* 펀딩 목록 */}
+        <SFundingUl>
+          {possibleFundingList.map((item, index) => (
+            <FundingComponent data={item} key={index} />
+          ))}
+        </SFundingUl>
       </SSection>
       <NavComponent />
     </SLayout>
@@ -87,6 +99,12 @@ const SInput = styled.input`
 const STextContainer = styled.div`
   display: flex;
   flex-flow: column nowrap;
+
+  gap: 8px;
+`;
+const SFundingUl = styled.ul`
+  display: flex;
+  flex-flow: row wrap;
 
   gap: 8px;
 `;

--- a/src/pages/Home/HomePage.jsx
+++ b/src/pages/Home/HomePage.jsx
@@ -1,5 +1,6 @@
 import styled from 'styled-components';
 import NavComponent from '../../components/common/NavComponent';
+import Calendar from '../../components/Home/Calendar';
 import icn_search from '../../assets/common/search.svg';
 
 const HomePage = () => {
@@ -21,8 +22,8 @@ const HomePage = () => {
         <STextContainer>
           <SH2>곧 마감되는 펀딩</SH2>
           <SB4>기간이 얼마 남지 않은 펀딩을 확인하세요!</SB4>
-          {/* 캘린더 컴포넌트 */}
         </STextContainer>
+        <Calendar />
       </SSection>
       <SSection>
         <SH2>참여 가능한 펀딩</SH2>

--- a/src/pages/Home/HomePage.jsx
+++ b/src/pages/Home/HomePage.jsx
@@ -1,11 +1,11 @@
 import styled from 'styled-components';
-import icn_search from '../../assets/common/search.svg';
 import NavComponent from '../../components/common/NavComponent';
+import icn_search from '../../assets/common/search.svg';
 
 const HomePage = () => {
   return (
     <SLayout>
-      <SSection>
+      <section>
         <SInput
           type='text'
           id='search-bar'
@@ -16,13 +16,13 @@ const HomePage = () => {
             console.log('검색 페이지 인풋필드 포커스');
           }}
         />
-      </SSection>
+      </section>
       <SSection>
-        <STextWrapper>
+        <STextContainer>
           <SH2>곧 마감되는 펀딩</SH2>
           <SB4>기간이 얼마 남지 않은 펀딩을 확인하세요!</SB4>
           {/* 캘린더 컴포넌트 */}
-        </STextWrapper>
+        </STextContainer>
       </SSection>
       <SSection>
         <SH2>참여 가능한 펀딩</SH2>
@@ -83,7 +83,7 @@ const SInput = styled.input`
     line-height: 140%;
   }
 `;
-const STextWrapper = styled.div`
+const STextContainer = styled.div`
   display: flex;
   flex-flow: column nowrap;
 

--- a/src/pages/List/ListPage.jsx
+++ b/src/pages/List/ListPage.jsx
@@ -42,12 +42,6 @@ const ListPage = ({ headerText, buttons, message }) => {
     setFundingList(FundingList);
   }, []);
 
-  const handleClick = (funding) => {
-    funding.status === 'IN_PROGRESS'
-      ? navigate(`/funding-detail/${funding.fundingId}/isOngoing`)
-      : navigate(`/funding-detail/${funding.fundingId}/end`);
-  };
-
   return (
     <SLayout>
       <BackHeaderComponent text={headerText} />
@@ -59,11 +53,7 @@ const ListPage = ({ headerText, buttons, message }) => {
       ) : (
         <SFundingContainer>
           {fundingList.map((funding, index) => (
-            <FundingComponent
-              result={funding}
-              key={index}
-              onClick={() => handleClick(funding)}
-            />
+            <FundingComponent data={funding} key={index} />
           ))}
         </SFundingContainer>
       )}

--- a/src/pages/Search/SearchPage.jsx
+++ b/src/pages/Search/SearchPage.jsx
@@ -62,7 +62,7 @@ const SearchPage = () => {
                 </div>
                 <div>
                   {result.stateTag == '진행중' ? (
-                    <TagComponent text='진행중' color='orange' />
+                    <TagComponent text='진행 중' color='jade' />
                   ) : (
                     <TagComponent text='종료' color='gray' />
                   )}


### PR DESCRIPTION
## ✅ PR 체크 리스트

- [ ] PR 제목: n주차 | 작업사항 요약
- [x] Reviewers, Assignees, Labels 설정

## ✨ 작업사항

- 퍼블리싱
  - 바텀시트 컴포넌트
    - bar 버튼 수평중앙정렬 오류 수정
    - 바텀시트 전체 높이 맞춤
    - action props 추가
      - `'transition'`(기본): 기존과 동일
      - `'back'`: cross 버튼 클릭 시 페이지 뒤로가기, background 이벤트리스너 비활성화
    - 바텀시트 컴포넌트 사용 중인 페이지 수정
  - 캐러셀 컴포넌트
    - 페이지가 1개일 때, 페이지네이션 `visibility: hidden;`
  - 친구 페이지
    - 캐러셀 데이터 3페이지까지 배열 자르기
    - 이메일이 입력되지 않았을 때 버튼 `disabled`
  - 홈 페이지
    - 캘린더 컴포넌트 추가
    - 참여 가능한 펀딩 추가
- 라우팅
  - 펀딩 개설
    - Context API 조건부 렌더링 페이지 이동 (모든 페이지)
    - Context API 데이터 관리 (`IndexPage.jsx`, `GiftSetPage.jsx`, 그외 페이지는 준비만)
  - 펀딩 참여
    - Context API 조건부 렌더링 페이지 이동 (`IndexPage.jsx`만)
    - Context API 데이터 관리 (`IndexPage.jsx`만)
- API 요청 Hook
  - `oauth.js`: 엑세스 토큰 재발급
- 코드 리팩토링
  - 패스워드 컴포넌트
  - 태그 컴포넌트
  - 펀딩 컴포넌트
  - 검색 페이지
  - 선물 추가 페이지
  - 펀딩 정보입력 페이지
  - 비밀번호 설정 페이지

## 📸 구현 상태

## 💡 리뷰 요청사항

- 선물 추가 페이지에서 뒤로가기 헤더 버튼 눌렀을 때 가장 마지막으로 입력한 선물 데이터가 뜨고 그걸 수정하게 하고 싶은데, 모든 데이터를 다시 다 입력해야만 다음 버튼이 눌려요! 왜 그런지 모르겠어요.
- 마지막 아이템 삭제하고 수정 아이템 저장하는 로직이 잘 작동하는지 확인 부탁드려요!
